### PR TITLE
Add development server logging with tail-logs command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ scratch/
 tests/temp/
 worktrees/
 .claude/
+logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Prefer using make commands when available:
 - Use `make test-unit` instead of `bun run test:unit`
 - Use `make test-integration` instead of `bun run test:integration`
 - Use `make test-all` instead of `bun run test:all`
+- Use `make tail-logs` to view last 20 lines of development server logs
 - Use `make install` instead of `bun install`
 
 ## Bun Usage

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ MAKEFLAGS += --no-builtin-rules
 # ---------------------- COMMANDS ---------------------------
 dev: # Start development server with hot reload
 	@echo "Starting development server.."
-	bun run dev
+	@mkdir -p logs
+	bun run dev 2>&1 | tee logs/dev.log
 
 format: # Format code with Biome
 	@echo "Formatting code.."
@@ -44,6 +45,10 @@ test-all: # Run both unit and integration tests
 	@echo "Running all tests.."
 	bun run test:all
 
+tail-logs: # Show last 20 lines of development server logs
+	@echo "Last 20 lines of development server logs:"
+	@tail -n 20 logs/dev.log 2>/dev/null || echo "No log file found. Run 'make dev' first."
+
 install: # Install dependencies
 	@echo "Installing dependencies.."
 	bun install
@@ -53,7 +58,7 @@ install: # Install dependencies
 # command, you need to add it to .PHONY below, otherwise it
 # won't work. E.g. `make run` wouldn't work if you have
 # `run` file in pwd.
-.PHONY: help dev format lint check test-unit test-coverage test-integration test-all install
+.PHONY: help dev format lint check test-unit test-coverage test-integration test-all tail-logs install
 
 # -----------------------------------------------------------
 # -----       (Makefile helpers and decoration)      --------

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ make test-integration
 
 # Run all tests
 make test-all
+
+# View development server logs (last 20 lines)
+make tail-logs
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary
- Add `make dev` logging that saves output to `logs/dev.log` using tee
- Add `make tail-logs` command to view last 20 lines of development server logs
- Create `logs/` directory and add to `.gitignore` for log file management

## Test plan
- [x] Run `make dev` and verify logs are saved to `logs/dev.log`
- [x] Run `make tail-logs` and verify it shows last 20 lines
- [x] Verify `logs/` directory is ignored by git
- [x] Update documentation in README.md and CLAUDE.md

🤖 Generated with [Claude Code](https://claude.ai/code)