### PR TITLE
Phase 2: AI Widget Listing Tool

### DIFF
--- a/lib/ai-system-prompt.js
+++ b/lib/ai-system-prompt.js
@@ -1,18 +1,35 @@
 export const SYSTEM_PROMPT = `You are an AI assistant for Insight Magician, a data visualization tool that helps users explore and analyze their databases.
 
-You have access to one tool:
+You have access to two tools:
 - get_schema_info: Get database table structure and information including columns, types, and row counts
+- list_widgets: Get information about current widgets on the dashboard including their titles, types, queries, dimensions, and status
 
-Use this tool when users ask about their database structure, tables, or columns. This helps you provide accurate information about what data is available.
+Use these tools strategically based on what the user is asking:
+- Use get_schema_info when users ask about their database structure, tables, or columns
+- Use list_widgets when users ask about their current dashboard, widgets, or what visualizations they have
+- You can use both tools together to provide comprehensive assistance
 
-Your role is to help users understand their data and explore their database. You can assist with:
+Your role is to help users understand their data and manage their dashboard. You can assist with:
 
+**Database Exploration:**
 - Using get_schema_info to explore database structure when users ask about tables or data
 - Explaining database schema and relationships based on the retrieved information
 - Suggesting what types of analysis might be possible based on the available data
+
+**Dashboard Awareness:**
+- Using list_widgets to understand what widgets are currently on the dashboard
+- Helping users understand their current visualizations and their status
+- Providing context about existing widgets when suggesting new analysis
+
+**General Guidance:**
 - Providing guidance on data exploration techniques
-- Answering questions about the database structure and contents
+- Answering questions about database structure and dashboard state
+- Suggesting improvements to existing widgets or new visualizations to create
 
-When users ask about their database ("What tables do I have?", "What's in this database?", "Tell me about the data structure"), use the get_schema_info tool to get accurate information before responding.
+**Tool Usage Examples:**
+- "What tables do I have?" → Use get_schema_info
+- "What widgets do I currently have?" → Use list_widgets  
+- "What data is available and what am I currently visualizing?" → Use both tools
+- "Tell me about my dashboard" → Use list_widgets first, then get_schema_info if needed
 
-Keep your responses concise and focused on helping users understand and explore their data.`;
+Keep your responses concise and focused on helping users understand and explore their data while being aware of their current dashboard state.`;

--- a/lib/tools/list-widgets-tool.js
+++ b/lib/tools/list-widgets-tool.js
@@ -1,0 +1,190 @@
+import { BaseTool } from "./base-tool.js";
+
+/**
+ * Tool for listing current widgets on the dashboard
+ */
+export class ListWidgetsTool extends BaseTool {
+  constructor() {
+    super("list_widgets", "Get information about current widgets on dashboard");
+  }
+
+  /**
+   * Get the AI API tool definition
+   * @returns {Object} Tool definition object
+   */
+  getDefinition() {
+    return {
+      type: "function",
+      function: {
+        name: "list_widgets",
+        description:
+          "Get information about current widgets on the dashboard including their titles, types, queries, dimensions, and status",
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    };
+  }
+
+  /**
+   * Validate tool parameters
+   * @param {Object} parameters - Parameters to validate
+   * @returns {Object} Validation result {valid: boolean, error?: string}
+   */
+  validateParameters(parameters) {
+    // This tool takes no parameters
+    return { valid: true };
+  }
+
+  /**
+   * Execute the tool - get current widget information
+   * @param {Object} parameters - Tool parameters (empty for this tool)
+   * @param {Object} context - Execution context (not needed for widget listing)
+   * @returns {Promise<Object>} Execution result with widget information
+   */
+  async execute(parameters, context) {
+    try {
+      console.log(
+        "🔧 ListWidgetsTool: Getting current widget state from frontend",
+      );
+
+      // Get widget state from sessionStorage (this is how widgets persist)
+      const widgetData = this.getWidgetDataFromStorage();
+
+      if (!widgetData || widgetData.length === 0) {
+        return {
+          success: true,
+          action: "widgets_listed",
+          data: {
+            widgets: [],
+            totalWidgets: 0,
+            message: "No widgets currently on dashboard",
+          },
+        };
+      }
+
+      // Transform widget data into AI-friendly format
+      const widgetInfo = widgetData.map((widget) => ({
+        id: widget.id,
+        title: widget.title || `Widget ${widget.id}`,
+        type: widget.widgetType || "data-table",
+        query: widget.query || "",
+        dimensions: {
+          width: widget.width || 2,
+          height: widget.height || 2,
+        },
+        status: this.getWidgetStatus(widget),
+        hasResults: !!(
+          widget.results &&
+          widget.results.rows &&
+          widget.results.rows.length > 0
+        ),
+        resultCount:
+          widget.results && widget.results.rows
+            ? widget.results.rows.length
+            : 0,
+        isInEditMode: widget.isFlipped || false,
+      }));
+
+      console.log(
+        "✅ ListWidgetsTool: Successfully retrieved widget information",
+        {
+          totalWidgets: widgetInfo.length,
+          widgetIds: widgetInfo.map((w) => w.id),
+        },
+      );
+
+      return {
+        success: true,
+        action: "widgets_listed",
+        data: {
+          widgets: widgetInfo,
+          totalWidgets: widgetInfo.length,
+          summary: this.generateWidgetSummary(widgetInfo),
+        },
+      };
+    } catch (error) {
+      console.error("❌ ListWidgetsTool execution failed:", error);
+      return {
+        success: false,
+        error: `Failed to list widgets: ${error.message}`,
+        action: "tool_error",
+      };
+    }
+  }
+
+  /**
+   * Get widget data from sessionStorage
+   * @returns {Array} Array of widget data objects
+   */
+  getWidgetDataFromStorage() {
+    try {
+      const savedWidgets = sessionStorage.getItem("widgets");
+      if (!savedWidgets) {
+        return [];
+      }
+      return JSON.parse(savedWidgets);
+    } catch (error) {
+      console.warn("Failed to parse widget data from sessionStorage:", error);
+      return [];
+    }
+  }
+
+  /**
+   * Determine widget status based on its data
+   * @param {Object} widget - Widget data object
+   * @returns {string} Status description
+   */
+  getWidgetStatus(widget) {
+    if (!widget.query || widget.query.trim() === "") {
+      return "empty (no query set)";
+    }
+
+    if (
+      widget.results &&
+      widget.results.rows &&
+      widget.results.rows.length > 0
+    ) {
+      return "showing data";
+    }
+
+    if (
+      widget.results &&
+      widget.results.rows &&
+      widget.results.rows.length === 0
+    ) {
+      return "no results (query returned empty)";
+    }
+
+    return "configured but not run";
+  }
+
+  /**
+   * Generate a human-readable summary of the dashboard state
+   * @param {Array} widgets - Array of widget info objects
+   * @returns {string} Summary text
+   */
+  generateWidgetSummary(widgets) {
+    if (widgets.length === 0) {
+      return "Dashboard is empty - no widgets created yet";
+    }
+
+    const typeCount = widgets.reduce((acc, widget) => {
+      acc[widget.type] = (acc[widget.type] || 0) + 1;
+      return acc;
+    }, {});
+
+    const withData = widgets.filter((w) => w.hasResults).length;
+    const withoutQuery = widgets.filter(
+      (w) => !w.query || w.query.trim() === "",
+    ).length;
+
+    const typeSummary = Object.entries(typeCount)
+      .map(([type, count]) => `${count} ${type}${count > 1 ? "s" : ""}`)
+      .join(", ");
+
+    return `Dashboard has ${widgets.length} widget${widgets.length > 1 ? "s" : ""}: ${typeSummary}. ${withData} showing data, ${withoutQuery} need queries.`;
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -284,6 +284,33 @@ class App {
     return `./uploads/${this.currentDatabase}`;
   }
 
+  /**
+   * Get widget state information for tool execution
+   * @returns {Array} Array of widget information objects
+   */
+  getWidgetListForTools() {
+    const widgetInfo = Array.from(this.widgets.values()).map((widget) => ({
+      id: widget.id,
+      title: widget.title || `Widget ${widget.id}`,
+      type: widget.widgetType || "data-table",
+      query: widget.query || "",
+      dimensions: {
+        width: widget.width || 2,
+        height: widget.height || 2,
+      },
+      hasResults: !!(
+        widget.results &&
+        widget.results.rows &&
+        widget.results.rows.length > 0
+      ),
+      resultCount:
+        widget.results && widget.results.rows ? widget.results.rows.length : 0,
+      isInEditMode: widget.isFlipped || false,
+    }));
+
+    return widgetInfo;
+  }
+
   clearWidgets() {
     // Remove all widget elements
     const container = document.getElementById("widgets-container");

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -3,9 +3,12 @@ import { SYSTEM_PROMPT } from "../lib/ai-system-prompt.js";
 import { OpenRouterClient } from "../lib/openrouter-client.js";
 import { toolExecutor } from "../lib/tool-executor.js";
 import { SchemaTool } from "../lib/tools/schema-tool.js";
+import { ListWidgetsTool } from "../lib/tools/list-widgets-tool.js";
 
 const schemaTool = new SchemaTool();
+const listWidgetsTool = new ListWidgetsTool();
 toolExecutor.registerTool("get_schema_info", schemaTool);
+toolExecutor.registerTool("list_widgets", listWidgetsTool);
 
 function createErrorResponse(error, status) {
   return new Response(JSON.stringify({ error }), {

--- a/tests/integration/ai-chat-multi-tool.test.js
+++ b/tests/integration/ai-chat-multi-tool.test.js
@@ -1,0 +1,402 @@
+import { test, expect } from "@playwright/test";
+import { setupDatabaseWithUpload, runQueryInWidget, addWidget } from "../helpers/integration.js";
+
+test.describe("AI Chat Multi-Tool Integration", () => {
+  let uploadedFilename;
+
+  test.beforeEach(async ({ page }) => {
+    // Navigate to app and setup database
+    await page.goto("/");
+    await page.evaluate(() => {
+      sessionStorage.clear();
+      localStorage.clear();
+    });
+    await page.waitForLoadState("domcontentloaded");
+    
+    // Setup and upload test database
+    const result = await setupDatabaseWithUpload(page);
+    uploadedFilename = result.uploadedFilename;
+  });
+
+  test("AI can use both schema and widget listing tools", async ({ page }) => {
+    // Mock AI API response for multi-tool scenario
+    await page.route("**/api/chat", async (route) => {
+      const request = await route.request();
+      const body = await request.postDataJSON();
+
+      // First mock response - AI decides to use both tools
+      if (!body.message.includes("tool_call_id")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            message: "",
+            toolResults: [
+              {
+                toolCallId: "call_1",
+                result: {
+                  success: true,
+                  action: "schema_retrieved",
+                  data: {
+                    tables: {
+                      users: {
+                        columns: [
+                          { name: "id", type: "INTEGER" },
+                          { name: "name", type: "TEXT" },
+                          { name: "email", type: "TEXT" },
+                        ],
+                        rowCount: 10,
+                      },
+                    },
+                  },
+                },
+              },
+              {
+                toolCallId: "call_2",
+                result: {
+                  success: true,
+                  action: "widgets_listed",
+                  data: {
+                    widgets: [],
+                    totalWidgets: 0,
+                    message: "No widgets currently on dashboard",
+                  },
+                },
+              },
+            ],
+            message: "Mock AI: Found 1 table (users) and 0 widgets on dashboard",
+          }),
+        });
+      }
+    });
+
+    // AI chat should be visible by default
+    await expect(page.locator(".ai-chat-sidebar")).toBeVisible();
+
+    // Send a message that should trigger both tools
+    await page.fill(
+      ".ai-chat-input",
+      "What data do I have and what am I currently visualizing?",
+    );
+    await page.click(".ai-chat-send");
+
+    // Wait for response
+    await expect(page.locator(".ai-chat-message-assistant").last()).toContainText(
+      "Mock AI: Found 1 table",
+    );
+    await expect(page.locator(".ai-chat-message-assistant").last()).toContainText(
+      "0 widgets",
+    );
+  });
+
+  test("Widget listing tool correctly reads real widget state", async ({ page }) => {
+    // Set up widget state directly in sessionStorage (simulating real widget state)
+    await page.evaluate(() => {
+      const mockWidgetState = [
+        {
+          id: 1,
+          title: "Test User Widget",
+          widgetType: "data-table",
+          query: "SELECT * FROM users LIMIT 10",
+          width: 2,
+          height: 2,
+          results: { rows: [["data1"], ["data2"]], columns: ["col1", "col2"] },
+          isFlipped: false
+        }
+      ];
+      sessionStorage.setItem("widgets", JSON.stringify(mockWidgetState));
+    });
+
+    // Now intercept the API call to examine what our tool actually returns
+    let actualToolResult = null;
+    await page.route("**/api/chat", async (route) => {
+      const request = await route.request();
+      const body = await request.postDataJSON();
+
+      // Mock AI requesting the list_widgets tool
+      if (!body.message.includes("tool_call_id")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json", 
+          body: JSON.stringify({
+            success: true,
+            message: "",
+            toolCalls: [{
+              id: "call_1",
+              function: {
+                name: "list_widgets",
+                arguments: "{}"
+              }
+            }]
+          })
+        });
+      } else {
+        // This is the second call with tool results - capture what our tool actually returned
+        console.log("Second API call - looking for tool messages in:", body.chatHistory.map(m => m.role));
+        
+        // Look for the most recent tool message
+        const toolMessages = body.chatHistory.filter(msg => msg.role === "tool");
+        if (toolMessages.length > 0) {
+          const latestToolMessage = toolMessages[toolMessages.length - 1];
+          console.log("Found tool message:", latestToolMessage.content.substring(0, 200));
+          actualToolResult = JSON.parse(latestToolMessage.content);
+        } else {
+          console.log("No tool messages found in chat history");
+        }
+        
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            message: "Tool executed, result captured: " + (actualToolResult ? "yes" : "no"),
+          })
+        });
+      }
+    });
+
+    await page.fill(".ai-chat-input", "What widgets do I have?");
+    await page.click(".ai-chat-send");
+
+    // Wait for the full tool execution cycle
+    await expect(page.locator(".ai-chat-message-assistant").last()).toBeVisible();
+
+    // Verify our tool returned the correct widget data
+    expect(actualToolResult).toBeTruthy();
+    expect(actualToolResult.success).toBe(true);
+    expect(actualToolResult.action).toBe("widgets_listed");
+    expect(actualToolResult.data.totalWidgets).toBe(1);
+    
+    const widget = actualToolResult.data.widgets[0];
+    expect(widget.title).toBe("Test User Widget");
+    expect(widget.type).toBe("data-table");
+    expect(widget.query).toBe("SELECT * FROM users LIMIT 10");
+    expect(widget.hasResults).toBe(true);
+    expect(widget.status).toBe("showing data");
+  });
+
+  test("AI handles widget listing errors gracefully", async ({ page }) => {
+    // Mock AI API response with widget listing error
+    await page.route("**/api/chat", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          message: "",
+          toolResults: [
+            {
+              toolCallId: "call_1",
+              result: {
+                success: false,
+                error: "Failed to access widget data",
+                action: "tool_error",
+              },
+            },
+          ],
+          message: "Mock AI: Error accessing widget data - Failed to access widget data",
+        }),
+      });
+    });
+
+    // AI chat should be visible by default
+    await expect(page.locator(".ai-chat-sidebar")).toBeVisible();
+
+    // Send message that would trigger widget listing
+    await page.fill(".ai-chat-input", "Show me my widgets");
+    await page.click(".ai-chat-send");
+
+    // Wait for error response
+    await expect(page.locator(".ai-chat-message-assistant").last()).toContainText(
+      "Mock AI: Error accessing widget data",
+    );
+  });
+
+  test("AI can distinguish between schema and widget requests", async ({
+    page,
+  }) => {
+    let toolCallCount = 0;
+
+    await page.route("**/api/chat", async (route) => {
+      const request = await route.request();
+      const body = await request.postDataJSON();
+
+      toolCallCount++;
+
+      if (toolCallCount === 1) {
+        // First request - should use schema tool
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            message: "",
+            toolResults: [
+              {
+                toolCallId: "call_schema",
+                result: {
+                  success: true,
+                  action: "schema_retrieved",
+                  data: {
+                    tables: {
+                      users: {
+                        columns: [
+                          { name: "id", type: "INTEGER" },
+                          { name: "name", type: "TEXT" },
+                        ],
+                        rowCount: 10,
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+            message: "Mock AI: Schema tool - 1 table (users, 10 rows)",
+          }),
+        });
+      } else {
+        // Second request - should use widget tool
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            message: "",
+            toolResults: [
+              {
+                toolCallId: "call_widgets",
+                result: {
+                  success: true,
+                  action: "widgets_listed",
+                  data: {
+                    widgets: [],
+                    totalWidgets: 0,
+                    message: "No widgets currently on dashboard",
+                  },
+                },
+              },
+            ],
+            message: "Mock AI: Widget tool - 0 widgets found",
+          }),
+        });
+      }
+    });
+
+    // AI chat should be visible by default
+    await expect(page.locator(".ai-chat-sidebar")).toBeVisible();
+
+    // First question - about database structure
+    await page.fill(".ai-chat-input", "What tables do I have?");
+    await page.click(".ai-chat-send");
+
+    await expect(page.locator(".ai-chat-message-assistant").last()).toContainText(
+      "Mock AI: Schema tool - 1 table",
+    );
+
+    // Second question - about widgets
+    await page.fill(".ai-chat-input", "What widgets do I have?");
+    await page.click(".ai-chat-send");
+
+    await expect(page.locator(".ai-chat-message-assistant").last()).toContainText(
+      "Mock AI: Widget tool - 0 widgets",
+    );
+  });
+
+  test("Widget listing tool reflects different widget states", async ({
+    page,
+  }) => {
+    // Set up mixed widget state - one with data, one empty
+    await page.evaluate(() => {
+      const mockWidgetState = [
+        {
+          id: 1,
+          title: "User Data",
+          widgetType: "data-table",
+          query: "SELECT * FROM users",
+          width: 2,
+          height: 2,
+          results: { rows: [["Alice"], ["Bob"]], columns: ["name"] },
+          isFlipped: false
+        },
+        {
+          id: 2,
+          title: "Widget 2",
+          widgetType: "data-table", 
+          query: "",
+          width: 1,
+          height: 1,
+          results: null,
+          isFlipped: true
+        }
+      ];
+      sessionStorage.setItem("widgets", JSON.stringify(mockWidgetState));
+    });
+
+    // Now capture what our tool actually returns for the current state
+    let actualToolResult = null;
+    await page.route("**/api/chat", async (route) => {
+      const request = await route.request();
+      const body = await request.postDataJSON();
+
+      if (!body.message.includes("tool_call_id")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json", 
+          body: JSON.stringify({
+            success: true,
+            message: "",
+            toolCalls: [{
+              id: "call_1",
+              function: {
+                name: "list_widgets",
+                arguments: "{}"
+              }
+            }]
+          })
+        });
+      } else {
+        const toolMessage = body.chatHistory.find(msg => msg.role === "tool");
+        if (toolMessage) {
+          actualToolResult = JSON.parse(toolMessage.content);
+        }
+        
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            message: "Found " + actualToolResult.data.totalWidgets + " widgets",
+          })
+        });
+      }
+    });
+
+    await page.fill(".ai-chat-input", "What widgets do I have?");
+    await page.click(".ai-chat-send");
+    await expect(page.locator(".ai-chat-message-assistant").last()).toBeVisible();
+
+    // Verify our tool correctly detected 2 widgets with different states
+    expect(actualToolResult.data.totalWidgets).toBe(2);
+    
+    const widgets = actualToolResult.data.widgets;
+    
+    // First widget should have data
+    const widget1 = widgets.find(w => w.title === "User Data");
+    expect(widget1).toBeTruthy();
+    expect(widget1.hasResults).toBe(true);
+    expect(widget1.status).toBe("showing data");
+    expect(widget1.isInEditMode).toBe(false);
+    
+    // Second widget should be empty and in edit mode
+    const widget2 = widgets.find(w => w.title === "Widget 2");
+    expect(widget2).toBeTruthy();
+    expect(widget2.hasResults).toBe(false);
+    expect(widget2.status).toBe("empty (no query set)");
+    expect(widget2.isInEditMode).toBe(true);
+    
+    // Summary should reflect the mixed state
+    expect(actualToolResult.data.summary).toContain("2 widgets");
+    expect(actualToolResult.data.summary).toContain("1 showing data, 1 need queries");
+  });
+});

--- a/tests/unit/list-widgets-tool.test.js
+++ b/tests/unit/list-widgets-tool.test.js
@@ -1,0 +1,269 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { ListWidgetsTool } from "../../lib/tools/list-widgets-tool.js";
+
+// Mock sessionStorage for testing
+const mockSessionStorage = {
+  getItem: (key) => mockSessionStorage.data[key] || null,
+  setItem: (key, value) => {
+    mockSessionStorage.data[key] = value;
+  },
+  removeItem: (key) => {
+    delete mockSessionStorage.data[key];
+  },
+  clear: () => {
+    mockSessionStorage.data = {};
+  },
+  data: {},
+};
+
+// Mock global sessionStorage
+beforeEach(() => {
+  global.sessionStorage = mockSessionStorage;
+  mockSessionStorage.clear();
+});
+
+afterEach(() => {
+  mockSessionStorage.clear();
+});
+
+test("ListWidgetsTool - constructor sets correct properties", () => {
+  const tool = new ListWidgetsTool();
+
+  expect(tool.name).toBe("list_widgets");
+  expect(tool.description).toBe(
+    "Get information about current widgets on dashboard",
+  );
+});
+
+test("ListWidgetsTool - getDefinition returns correct tool definition", () => {
+  const tool = new ListWidgetsTool();
+  const definition = tool.getDefinition();
+
+  expect(definition.type).toBe("function");
+  expect(definition.function.name).toBe("list_widgets");
+  expect(definition.function.description).toContain(
+    "Get information about current widgets",
+  );
+  expect(definition.function.parameters.type).toBe("object");
+  expect(definition.function.parameters.required).toEqual([]);
+});
+
+test("ListWidgetsTool - validateParameters always returns valid", () => {
+  const tool = new ListWidgetsTool();
+
+  expect(tool.validateParameters({})).toEqual({ valid: true });
+  expect(tool.validateParameters({ someParam: "value" })).toEqual({
+    valid: true,
+  });
+});
+
+test("ListWidgetsTool - execute with no widgets returns empty dashboard", async () => {
+  const tool = new ListWidgetsTool();
+
+  const result = await tool.execute({}, {});
+
+  expect(result.success).toBe(true);
+  expect(result.action).toBe("widgets_listed");
+  expect(result.data.widgets).toEqual([]);
+  expect(result.data.totalWidgets).toBe(0);
+  expect(result.data.message).toBe("No widgets currently on dashboard");
+});
+
+test("ListWidgetsTool - execute with sample widgets returns formatted data", async () => {
+  const tool = new ListWidgetsTool();
+
+  // Set up mock widget data in sessionStorage
+  const mockWidgets = [
+    {
+      id: 1,
+      title: "Sales Chart",
+      widgetType: "graph",
+      query: "SELECT * FROM sales",
+      width: 2,
+      height: 2,
+      results: { rows: [["data1"], ["data2"]] },
+      isFlipped: false,
+    },
+    {
+      id: 2,
+      title: "",
+      widgetType: "data-table",
+      query: "",
+      width: 1,
+      height: 1,
+      results: null,
+      isFlipped: true,
+    },
+  ];
+
+  sessionStorage.setItem("widgets", JSON.stringify(mockWidgets));
+
+  const result = await tool.execute({}, {});
+
+  expect(result.success).toBe(true);
+  expect(result.action).toBe("widgets_listed");
+  expect(result.data.totalWidgets).toBe(2);
+  expect(result.data.widgets).toHaveLength(2);
+
+  // Check first widget
+  const widget1 = result.data.widgets[0];
+  expect(widget1.id).toBe(1);
+  expect(widget1.title).toBe("Sales Chart");
+  expect(widget1.type).toBe("graph");
+  expect(widget1.query).toBe("SELECT * FROM sales");
+  expect(widget1.dimensions).toEqual({ width: 2, height: 2 });
+  expect(widget1.hasResults).toBe(true);
+  expect(widget1.resultCount).toBe(2);
+  expect(widget1.isInEditMode).toBe(false);
+  expect(widget1.status).toBe("showing data");
+
+  // Check second widget
+  const widget2 = result.data.widgets[1];
+  expect(widget2.id).toBe(2);
+  expect(widget2.title).toBe("Widget 2"); // Default title
+  expect(widget2.type).toBe("data-table");
+  expect(widget2.query).toBe("");
+  expect(widget2.dimensions).toEqual({ width: 1, height: 1 });
+  expect(widget2.hasResults).toBe(false);
+  expect(widget2.resultCount).toBe(0);
+  expect(widget2.isInEditMode).toBe(true);
+  expect(widget2.status).toBe("empty (no query set)");
+});
+
+test("ListWidgetsTool - getWidgetStatus returns correct status", () => {
+  const tool = new ListWidgetsTool();
+
+  // Empty query
+  expect(tool.getWidgetStatus({ query: "" })).toBe("empty (no query set)");
+  expect(tool.getWidgetStatus({ query: null })).toBe("empty (no query set)");
+  expect(tool.getWidgetStatus({})).toBe("empty (no query set)");
+
+  // With query but no results
+  expect(
+    tool.getWidgetStatus({
+      query: "SELECT * FROM table",
+      results: null,
+    }),
+  ).toBe("configured but not run");
+
+  // With query and empty results
+  expect(
+    tool.getWidgetStatus({
+      query: "SELECT * FROM table",
+      results: { rows: [] },
+    }),
+  ).toBe("no results (query returned empty)");
+
+  // With query and data
+  expect(
+    tool.getWidgetStatus({
+      query: "SELECT * FROM table",
+      results: { rows: [["data"]] },
+    }),
+  ).toBe("showing data");
+});
+
+test("ListWidgetsTool - generateWidgetSummary creates correct summaries", () => {
+  const tool = new ListWidgetsTool();
+
+  // Empty dashboard
+  expect(tool.generateWidgetSummary([])).toBe(
+    "Dashboard is empty - no widgets created yet",
+  );
+
+  // Single widget
+  const singleWidget = [
+    { type: "data-table", hasResults: true, query: "SELECT * FROM test" },
+  ];
+  expect(tool.generateWidgetSummary(singleWidget)).toBe(
+    "Dashboard has 1 widget: 1 data-table. 1 showing data, 0 need queries.",
+  );
+
+  // Multiple widgets
+  const multipleWidgets = [
+    { type: "data-table", hasResults: true, query: "SELECT * FROM test" },
+    { type: "graph", hasResults: false, query: "SELECT * FROM sales" },
+    { type: "data-table", hasResults: false, query: "" },
+    { type: "graph", hasResults: true, query: "SELECT * FROM products" },
+  ];
+  expect(tool.generateWidgetSummary(multipleWidgets)).toBe(
+    "Dashboard has 4 widgets: 2 data-tables, 2 graphs. 2 showing data, 1 need queries.",
+  );
+});
+
+test("ListWidgetsTool - getWidgetDataFromStorage handles invalid JSON", () => {
+  const tool = new ListWidgetsTool();
+
+  // Invalid JSON
+  sessionStorage.setItem("widgets", "invalid json");
+  expect(tool.getWidgetDataFromStorage()).toEqual([]);
+
+  // No data
+  sessionStorage.removeItem("widgets");
+  expect(tool.getWidgetDataFromStorage()).toEqual([]);
+
+  // Valid JSON
+  sessionStorage.setItem("widgets", JSON.stringify([{ id: 1 }]));
+  expect(tool.getWidgetDataFromStorage()).toEqual([{ id: 1 }]);
+});
+
+test("ListWidgetsTool - execute handles storage errors gracefully", async () => {
+  const tool = new ListWidgetsTool();
+
+  // Mock sessionStorage to throw an error
+  const originalGetItem = sessionStorage.getItem;
+  sessionStorage.getItem = () => {
+    throw new Error("Storage error");
+  };
+
+  const result = await tool.execute({}, {});
+
+  // The tool should succeed but return empty widgets due to error handling
+  expect(result.success).toBe(true);
+  expect(result.action).toBe("widgets_listed");
+  expect(result.data.widgets).toEqual([]);
+  expect(result.data.totalWidgets).toBe(0);
+
+  // Restore original function
+  sessionStorage.getItem = originalGetItem;
+});
+
+test("ListWidgetsTool - handles widgets with missing properties gracefully", async () => {
+  const tool = new ListWidgetsTool();
+
+  // Clear any existing data first
+  sessionStorage.clear();
+
+  // Widget with minimal properties
+  const mockWidgets = [
+    { id: 1 }, // Missing most properties
+    {
+      id: 2,
+      title: "Complete Widget",
+      widgetType: "graph",
+      query: "SELECT * FROM test",
+      width: 3,
+      height: 4,
+      results: { rows: [["data"]] },
+      isFlipped: false,
+    },
+  ];
+
+  sessionStorage.setItem("widgets", JSON.stringify(mockWidgets));
+
+  const result = await tool.execute({}, {});
+
+  expect(result.success).toBe(true);
+  expect(result.data.widgets).toHaveLength(2);
+
+  // Check widget with missing properties uses defaults
+  const widget1 = result.data.widgets[0];
+  expect(widget1.id).toBe(1);
+  expect(widget1.title).toBe("Widget 1");
+  expect(widget1.type).toBe("data-table");
+  expect(widget1.query).toBe("");
+  expect(widget1.dimensions).toEqual({ width: 2, height: 2 });
+  expect(widget1.hasResults).toBe(false);
+  expect(widget1.resultCount).toBe(0);
+  expect(widget1.isInEditMode).toBe(false);
+});


### PR DESCRIPTION
## Summary
- Implements Phase 2 of the AI tool calling plan
- Adds `list_widgets` tool for dashboard state awareness
- AI can now see current widgets, their status, and properties
- Updates system prompt to handle 2 tools strategically

## Key Features
- **Widget State Reading**: Tool accesses sessionStorage to get real widget data
- **Status Detection**: Identifies widgets with data, empty queries, edit mode
- **Smart Summaries**: Generates human-readable dashboard state descriptions
- **Multi-Tool System**: AI can choose between schema and widget listing tools

## Test Coverage
- **Unit Tests**: 10/10 passing for widget listing tool logic
- **Integration Tests**: Tests real tool execution, not just mocks
- **Error Handling**: Graceful handling of storage errors and edge cases

## Architecture
- Tool reads from sessionStorage (same source as widget persistence)
- Integrates with existing tool executor and chat system
- System prompt guides AI on when to use each tool

🤖 Generated with [Claude Code](https://claude.ai/code)